### PR TITLE
Add language and words to copySettings; Sync version in package-lock.json to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vlabo/cspell-lsp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vlabo/cspell-lsp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@vlabo/cspell-lsp": "^1.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,6 +147,8 @@ export async function getSettingsForDocument(textDocument: TextDocument) {
 }
 
 function copySettings(from: CSpellSettings , to: CSpellSettings) {
+  if(from.language) to.language = from.language;
+  if(from.words) to.words = from.words;
   if(from.userWords) to.userWords = from.userWords;
   if(from.caseSensitive) to.caseSensitive = from.caseSensitive;
   if(from.dictionaries) to.dictionaries = from.dictionaries;


### PR DESCRIPTION
- **Sync version in package-lock.json to 1.1.0**
- **Add language and words to copySettings**

---

I'm not entirely sure which settings listed in [VSCode cspell][vscode-cspell]
are passed to cspell and which are for the plugin itself, so I didn't
add them all, but these two definitely affects cspell CLI.

[vscode-cspell]: https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker#vs-code-configuration-settings
