### PR TITLE
Support adding words to workspace `words` and custom dictionaries; read configs with cspell-lib `readSettings()`

### DIFF
--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -87,6 +87,29 @@ class CodeActionHandler {
       },
     });
 
+    const settings = await getSettingsForDocument(ctx.textDocument);
+    const dictionaries = settings.dictionaries ?? [];
+    if (settings.dictionaryDefinitions && settings.dictionaryDefinitions.length > 0) {
+      const mutableDictionaries = settings.dictionaryDefinitions
+        .filter((dict) => 'path' in dict && 'addWords' in dict && dict.addWords)
+        .filter((dict) => dictionaries.indexOf(dict.name) >= 0 && dictionaries.indexOf(`!${dict.name}`) < 0);
+      const customDictionaryActions = mutableDictionaries.map((dict) => ({
+        title: `Add to ${dict.name} dictionary`,
+        kind: CodeActionKind.QuickFix,
+        diagnostics: diagnostics,
+        command: {
+          title: `Add to ${dict.name} dictionary`,
+          command: "AddToCustomDictionary",
+          arguments: [{
+            ...arg,
+            name: dict.name,
+            path: dict.path
+          }]
+        }
+      }));
+      actions.push(...customDictionaryActions);
+    }
+
     return actions;
   }
 

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -67,14 +67,24 @@ class CodeActionHandler {
     }
 
     actions.push({
-      title: "Add to config",
+      title: "Add to user words in config",
        kind: CodeActionKind.QuickFix,
        diagnostics: diagnostics,
        command: {
-        title: "Add to config",
-        command: "AddToConfig",
+        title: "Add to user words in config",
+        command: "AddToUserWordsConfig",
         arguments: [arg]
        },
+    });
+    actions.push({
+      title: "Add to workspace words in config",
+      kind: CodeActionKind.QuickFix,
+      diagnostics: diagnostics,
+      command: {
+        title: "Add to workspace words in config",
+        command: "AddToWorkspaceWordsConfig",
+        arguments: [arg]
+      },
     });
 
     return actions;

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,7 +90,7 @@ connection.onInitialize((_: InitializeParams) => {
         codeActionKinds: [CodeActionKind.QuickFix],
       },
       executeCommandProvider: {
-        commands: ['AddToConfig'],
+        commands: ['AddToUserWordsConfig', 'AddToWorkspaceWordsConfig'],
       }
     },
   };
@@ -161,7 +161,7 @@ function copySettings(from: CSpellSettings , to: CSpellSettings) {
 
 connection.onExecuteCommand((params: ExecuteCommandParams) => {
   const { command, arguments: args } = params;
-  if (command == "AddToConfig") {
+  if (command == "AddToUserWordsConfig" || command == "AddToWorkspaceWordsConfig") {
     const diagnosticInfo = args![0];
     const { uri, range } = diagnosticInfo;
     const document = documents.get(uri!);
@@ -170,12 +170,13 @@ connection.onExecuteCommand((params: ExecuteCommandParams) => {
     }
     const word = document.getText(range);
     if (word) {
+      const attribute = command == "AddToUserWordsConfig" ? "userWords" : "words"
       // Add the word to the user words array
-      if (!userSettings.userWords) {
-        userSettings.userWords = [];
+      if (!userSettings[attribute]) {
+        userSettings[attribute] = [];
       }
       // WARN: Array must be copied, or the cspell lib does not see the change!?
-      userSettings.userWords = [...userSettings.userWords, word];
+      userSettings[attribute] = [...userSettings[attribute], word];
 
       // Write to file
       fs.writeFileSync(mainSettingsPath, JSON.stringify(userSettings, null, 2));


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`7181b16`](https://github.com/vlabo/cspell-lsp/pull/10/commits/7181b1622ab1d8afae18dee3850b312e9825fe18) Support adding words to workspace dictionary in code actions



### [`7fb697b`](https://github.com/vlabo/cspell-lsp/pull/10/commits/7fb697bf0a55358ae575744a822aa058f3895786) Leverage cspell-lib readSettings() to parse config files

For one thing, combined with getDefaultConfigLoader(), this seems to
have fixed the caching problem; for another, we now have fully-parsed
configs including imported ones.

Note readSettings() supports .yaml, .js, and .cjs too. The code actions
only support JSONs though they are always offered to users. Users will
see an error if their config is not in JSON. This should be less
confusing than hiding the code actions.


### [`fca7dff`](https://github.com/vlabo/cspell-lsp/pull/10/commits/fca7dff535fa0e9aeab07f31729e8a41dfcb94e7) Support adding words to custom dictionaries



<!-- === GH HISTORY FENCE === -->


---

Sorry the third patch shuffled the code around a little. It's probably easier to review with 'Hide whitespace' on.