### PR TITLE
Read cspell global config; watch --config file changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ npm install -g @vlabo/cspell-lsp
 --stdio      -> Type of communication with the editor. 
 ```
 
+`cspell-lsp` also reads the global `cspell.json` in:
+
+- Linux: `~/.config/cspell/`
+- macOS: `~/Library/Preferences/cspell/`
+- Windows: `%AppData%\cspell\Config\`
+
 ## Helix config
 `helix/languages.toml:`  
 ```toml

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,6 +105,18 @@ connection.onInitialized(async () => {
   }
 
   const watchers: FileSystemWatcher[] = [{ globPattern: '**/cspell.{json,yaml,yml}' }, { globPattern: '**/.cspell.json' }];
+  if (options.config) {
+    let baseUri: string;
+    let pattern: string;
+    if (path.isAbsolute(options.config)) {
+      baseUri = 'file://' + path.dirname(options.config);
+      pattern = path.basename(options.config);
+    } else {
+      baseUri = 'file://' + process.cwd();
+      pattern = options.config.startsWith('.' + path.sep) ? options.config.substring(2) : options.config;
+    }
+    watchers.push({ globPattern: { baseUri, pattern } });
+  }
   const globalConfig = await getGlobalSettingsAsync();
   // getGlobalSettingsAsync returns with globRoot even if global config doesn't exist
   if (globalConfig.globRoot && fs.existsSync(globalConfig.globRoot)) {


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`f6580fc`](https://github.com/vlabo/cspell-lsp/pull/15/commits/f6580fcc0a62d8eb3d7358f1023412151249196b) Support cspell global config

mergeSettings() ignores a few attributes [1].

Sorry I didn't do a great job testing [2].

[1] https://github.com/streetsidesoftware/cspell/blob/1bee5f5aa4429a1b1ae0e88934b093c5440b44dc/packages/cspell-lib/src/lib/Settings/CSpellSettingsServer.ts#L145-L152
[2] https://github.com/vlabo/cspell-lsp/commit/3284a9025934dda9a5719c388f0023c85fc023c9


### [`527ad28`](https://github.com/vlabo/cspell-lsp/pull/15/commits/527ad28c1c0b0b01a5f6904ebb4cafa3a5688ddf) Add config file from command line args to watchers



<!-- === GH HISTORY FENCE === -->
