### PR TITLE
Resurrect AddToCustomDictionary code action

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import {
   getGlobalSettingsAsync,
   mergeSettings,
   readSettings,
+  refreshDictionaryCache,
 } from "cspell-lib";
 
 import * as Validator from './validator.js';
@@ -44,7 +45,7 @@ const options = commandLineArgs(optionDefinitions);
 
 let defaultSettings: CSpellUserSettings = {};
 
-const COMMANDS = ['AddToUserWordsConfig', 'AddToWorkspaceWordsConfig']
+const COMMANDS = ['AddToUserWordsConfig', 'AddToWorkspaceWordsConfig', 'AddToCustomDictionary']
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
@@ -249,6 +250,14 @@ connection.onExecuteCommand(async (params: ExecuteCommandParams) => {
 
     revalidateAllOpenDocuments();
     return { result: `Added "${word}" to the dictionary.` };
+  }
+  if (command == "AddToCustomDictionary") {
+    // Assumes the file breaks lines with LF and it ends with a \n already,
+    // instead of trying to be clever
+    fs.appendFileSync(dictPath, `${word}\n`);
+
+    refreshDictionaryCache(0).then(() => revalidateAllOpenDocuments());
+    return { result: `Added ${word} to ${dictName} dictionary.` };
   }
 });
 


### PR DESCRIPTION
Closes #16.

---

Edit: On a second thought... The only downside is invalidating the settings cache unnecessarily in some corner cases. I pushed a second commit to watch custom dictionaries.

~~I didn't add custom dictionaries to watchers mainly because I wasn't sure how to de-register them when they are removed from config files or get negated with `!dictName`.~~

I tested
```typescript
await connection.client.register(DidChangeWatchedFilesNotification.type, { watchers });
await connection.client.register(DidChangeWatchedFilesNotification.type, { watchers: [] });
```
...and I just got two watchers in Neovim:
```lua
  dynamic_capabilities = {
    capabilities = <26>{
      ["workspace/didChangeConfiguration"] = { {
          id = "70012a9b-eded-4037-96b7-2070277f99fa",
          method = "workspace/didChangeConfiguration",
          registerOptions = vim.empty_dict()
        } },
      ["workspace/didChangeWatchedFiles"] = { {
          id = "f643a565-5032-428d-8fbb-0f335a6b7a6c",
          method = "workspace/didChangeWatchedFiles",
          registerOptions = {
            watchers = { {
                globPattern = "**/cspell.{json,yaml,yml}"
              }, {
                globPattern = "**/.cspell.json"
              }, {
                globPattern = {
                  baseUri = "file:///home/frederick/Programming/JavaScript/cspell-lsp",
                  pattern = ".cSpell.json"
                }
              } }
          }
        }, {
          id = "55fb65b4-5f20-47a5-92a8-6264b0ef0dd6",
          method = "workspace/didChangeWatchedFiles",
          registerOptions = {
            watchers = {}
          }
        } },
      ["workspace/didChangeWorkspaceFolders"] = { {
          id = "9f368205-7fc0-46f2-96f0-7566a375e9c9",
          method = "workspace/didChangeWorkspaceFolders",
          registerOptions = vim.empty_dict()
        } }
    },
    client_id = 1,
    get = <function 7>,
    register = <function 8>,
    supports = <function 9>,
    supports_registration = <function 10>,
    unregister = <function 11>
  },
```